### PR TITLE
ci: reduce duplication of action runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ concurrency:
 jobs:
   format:
     name: Formatting
+
+    # Do not run on PRs from the same repo, since `push` already handles them.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -28,6 +32,9 @@ jobs:
 
   test:
     name: Tests
+
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
     runs-on: ubuntu-latest
     env:
       RUST_LOG: "trace"
@@ -58,6 +65,9 @@ jobs:
 
   clippy:
     name: Clippy; Destroyer of Realities.
+
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
     runs-on: ubuntu-latest
     env:
       RUST_LOG: "trace"


### PR DESCRIPTION
This stops both `push` and `pull_request` actions from running on the same PR (from branches in this repo).
